### PR TITLE
Fixed list type casting bug

### DIFF
--- a/video_transformers/trainer.py
+++ b/video_transformers/trainer.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict, Union, List
+from typing import Dict, List, Union
 
 import numpy as np
 import torch

--- a/video_transformers/trainer.py
+++ b/video_transformers/trainer.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict, Union
+from typing import Dict, Union, List
 
 import numpy as np
 import torch
@@ -30,7 +30,7 @@ class BaseTrainer:
         mixed_precision: str = "no",
         output_dir: str = "runs",
         seed: int = 42,
-        trackers: list[GeneralTracker] = None,
+        trackers: List[GeneralTracker] = None,
         checkpoint_save: bool = True,
         checkpoint_save_interval: int = 1,
         checkpoint_save_policy: str = "epoch",


### PR DESCRIPTION
Running this line from the example:

```python
from video_transformers.trainer import trainer_factory
```

 results in this error:

```python
TypeError: 'type' object is not subscribable
```

The problems is that `list` is used instead of 'typing.List' in the type hinting. Fixed it in this fork.